### PR TITLE
fix: pyarrow 0.21 compatibility hotfix

### DIFF
--- a/src/pysetl/storage/connector/file_connector.py
+++ b/src/pysetl/storage/connector/file_connector.py
@@ -129,7 +129,7 @@ class FileConnector(Connector, HasReader, HasWriter, CanDrop, CanPartition):
                 allow_bucket_deletion=True,
             )
 
-        fs, _ = FileSystem.from_uri(uri=self.uri.geturl())  # type: ignore
+        fs, _ = FileSystem.from_uri(self.uri.geturl())  # type: ignore
 
         return fs
 


### PR DESCRIPTION
pyarrow 0.21 introduced a bug by eliminating the @staticmethod from Filesystem.from_uri.

Check https://github.com/apache/arrow/issues/47179 for more information.